### PR TITLE
replace ListView with WinUI.TableView as log viewer

### DIFF
--- a/sample/WinUI3SampleApp/LogEventLevelToBrushConverter.cs
+++ b/sample/WinUI3SampleApp/LogEventLevelToBrushConverter.cs
@@ -8,7 +8,7 @@ namespace WinUI3SampleApp;
 
 public class LogEventLevelToBrushConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, string language)
+    public object? Convert(object value, Type targetType, object parameter, string language)
     {
         return (LogEventLevel)value switch
         {
@@ -17,7 +17,7 @@ public class LogEventLevelToBrushConverter : IValueConverter
             LogEventLevel.Warning => new SolidColorBrush(Colors.Yellow),
             LogEventLevel.Error => new SolidColorBrush(Colors.HotPink),
             LogEventLevel.Fatal => new SolidColorBrush(Colors.Red),
-            LogEventLevel.Information or _ => null!,
+            LogEventLevel.Information or _ => null,
         };
     }
 

--- a/sample/WinUI3SampleApp/LogEventLevelToBrushConverter.cs
+++ b/sample/WinUI3SampleApp/LogEventLevelToBrushConverter.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.UI;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+using Serilog.Events;
+using System;
+
+namespace WinUI3SampleApp;
+
+public class LogEventLevelToBrushConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        return (LogEventLevel)value switch
+        {
+            LogEventLevel.Verbose => new SolidColorBrush(Colors.LightGray),
+            LogEventLevel.Debug => new SolidColorBrush(Colors.Gray),
+            LogEventLevel.Warning => new SolidColorBrush(Colors.Yellow),
+            LogEventLevel.Error => new SolidColorBrush(Colors.HotPink),
+            LogEventLevel.Fatal => new SolidColorBrush(Colors.Red),
+            LogEventLevel.Information or _ => value,
+        };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/sample/WinUI3SampleApp/LogEventLevelToBrushConverter.cs
+++ b/sample/WinUI3SampleApp/LogEventLevelToBrushConverter.cs
@@ -17,7 +17,7 @@ public class LogEventLevelToBrushConverter : IValueConverter
             LogEventLevel.Warning => new SolidColorBrush(Colors.Yellow),
             LogEventLevel.Error => new SolidColorBrush(Colors.HotPink),
             LogEventLevel.Fatal => new SolidColorBrush(Colors.Red),
-            LogEventLevel.Information or _ => value,
+            LogEventLevel.Information or _ => null!,
         };
     }
 

--- a/sample/WinUI3SampleApp/MainPage.xaml
+++ b/sample/WinUI3SampleApp/MainPage.xaml
@@ -6,181 +6,19 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:WinUI3SampleApp"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:table="using:WinUI.TableView"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
     <Page.Resources>
-        <Style
+        <Style 
             BasedOn="{StaticResource DefaultToggleButtonStyle}"
-            TargetType="ToggleButton">
+               TargetType="ToggleButton">
             <Setter Property="HorizontalAlignment" Value="Stretch" />
         </Style>
-
-        <GridLength x:Key="TimestampColumnGridLength">210</GridLength>
-        <GridLength x:Key="LogLevelColumnGridLength">90</GridLength>
-        <x:Double x:Key="MessageColumnMinWidth">500</x:Double>
-
+        
         <local:TrueToVisibleConverter x:Key="TrueToVisibleConverter" />
-
-        <local:LogItemDataTemplateSelector x:Key="LogItemDataTemplateSelector">
-            <local:LogItemDataTemplateSelector.VerboseTemplate>
-                <DataTemplate x:DataType="local:LogItem">
-                    <Grid>
-                        <Grid.Resources>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="LightGray" />
-                            </Style>
-                        </Grid.Resources>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="{StaticResource TimestampColumnGridLength}" />
-                            <ColumnDefinition Width="{StaticResource LogLevelColumnGridLength}" />
-                            <ColumnDefinition
-                                Width="*"
-                                MinWidth="{StaticResource MessageColumnMinWidth}" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            Grid.Column="0"
-                            Text="{x:Bind Timestamp}" />
-                        <TextBlock
-                            Grid.Column="1"
-                            Text="{x:Bind Level}" />
-                        <TextBlock
-                            Grid.Column="2"
-                            Text="{x:Bind Message}" />
-                    </Grid>
-                </DataTemplate>
-            </local:LogItemDataTemplateSelector.VerboseTemplate>
-            <local:LogItemDataTemplateSelector.DebugTemplate>
-                <DataTemplate x:DataType="local:LogItem">
-                    <Grid>
-                        <Grid.Resources>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="Gray" />
-                            </Style>
-                        </Grid.Resources>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="{StaticResource TimestampColumnGridLength}" />
-                            <ColumnDefinition Width="{StaticResource LogLevelColumnGridLength}" />
-                            <ColumnDefinition
-                                Width="*"
-                                MinWidth="{StaticResource MessageColumnMinWidth}" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            Grid.Column="0"
-                            Text="{x:Bind Timestamp}" />
-                        <TextBlock
-                            Grid.Column="1"
-                            Text="{x:Bind Level}" />
-                        <TextBlock
-                            Grid.Column="2"
-                            Text="{x:Bind Message}" />
-                    </Grid>
-                </DataTemplate>
-            </local:LogItemDataTemplateSelector.DebugTemplate>
-            <local:LogItemDataTemplateSelector.InformationTemplate>
-                <DataTemplate x:DataType="local:LogItem">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="{StaticResource TimestampColumnGridLength}" />
-                            <ColumnDefinition Width="{StaticResource LogLevelColumnGridLength}" />
-                            <ColumnDefinition
-                                Width="*"
-                                MinWidth="{StaticResource MessageColumnMinWidth}" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            Grid.Column="0"
-                            Text="{x:Bind Timestamp}" />
-                        <TextBlock
-                            Grid.Column="1"
-                            Text="{x:Bind Level}" />
-                        <TextBlock
-                            Grid.Column="2"
-                            Text="{x:Bind Message}" />
-                    </Grid>
-                </DataTemplate>
-            </local:LogItemDataTemplateSelector.InformationTemplate>
-            <local:LogItemDataTemplateSelector.WarningTemplate>
-                <DataTemplate x:DataType="local:LogItem">
-                    <Grid>
-                        <Grid.Resources>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="Yellow" />
-                            </Style>
-                        </Grid.Resources>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="{StaticResource TimestampColumnGridLength}" />
-                            <ColumnDefinition Width="{StaticResource LogLevelColumnGridLength}" />
-                            <ColumnDefinition
-                                Width="*"
-                                MinWidth="{StaticResource MessageColumnMinWidth}" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            Grid.Column="0"
-                            Text="{x:Bind Timestamp}" />
-                        <TextBlock
-                            Grid.Column="1"
-                            Text="{x:Bind Level}" />
-                        <TextBlock
-                            Grid.Column="2"
-                            Text="{x:Bind Message}" />
-                    </Grid>
-                </DataTemplate>
-            </local:LogItemDataTemplateSelector.WarningTemplate>
-            <local:LogItemDataTemplateSelector.ErrorTemplate>
-                <DataTemplate x:DataType="local:LogItem">
-                    <Grid>
-                        <Grid.Resources>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="HotPink" />
-                            </Style>
-                        </Grid.Resources>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="{StaticResource TimestampColumnGridLength}" />
-                            <ColumnDefinition Width="{StaticResource LogLevelColumnGridLength}" />
-                            <ColumnDefinition
-                                Width="*"
-                                MinWidth="{StaticResource MessageColumnMinWidth}" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            Grid.Column="0"
-                            Text="{x:Bind Timestamp}" />
-                        <TextBlock
-                            Grid.Column="1"
-                            Text="{x:Bind Level}" />
-                        <TextBlock
-                            Grid.Column="2"
-                            Text="{x:Bind Message}" />
-                    </Grid>
-                </DataTemplate>
-            </local:LogItemDataTemplateSelector.ErrorTemplate>
-            <local:LogItemDataTemplateSelector.FatalTemplate>
-                <DataTemplate x:DataType="local:LogItem">
-                    <Grid>
-                        <Grid.Resources>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="Red" />
-                            </Style>
-                        </Grid.Resources>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="{StaticResource TimestampColumnGridLength}" />
-                            <ColumnDefinition Width="{StaticResource LogLevelColumnGridLength}" />
-                            <ColumnDefinition
-                                Width="*"
-                                MinWidth="{StaticResource MessageColumnMinWidth}" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            Grid.Column="0"
-                            Text="{x:Bind Timestamp}" />
-                        <TextBlock
-                            Grid.Column="1"
-                            Text="{x:Bind Level}" />
-                        <TextBlock
-                            Grid.Column="2"
-                            Text="{x:Bind Message}" />
-                    </Grid>
-                </DataTemplate>
-            </local:LogItemDataTemplateSelector.FatalTemplate>
-        </local:LogItemDataTemplateSelector>
+        <local:LogEventLevelToBrushConverter x:Key="LogEventLevelToBrushConverter" />
     </Page.Resources>
 
     <Grid
@@ -247,59 +85,46 @@
         </StackPanel>
 
         <!--  LogViewer  -->
-        <Grid
-            Grid.Column="1"
-            BorderBrush="{ThemeResource ControlElevationBorderBrush}"
-            BorderThickness="1"
-            CornerRadius="{ThemeResource ControlCornerRadius}"
-            RowDefinitions="Auto,*">
-            <Grid Grid.Row="0">
-                <Grid.Resources>
-                    <Style
-                        BasedOn="{StaticResource DefaultButtonStyle}"
-                        TargetType="Button">
-                        <Setter Property="HorizontalAlignment" Value="Stretch" />
-                        <Setter Property="HorizontalContentAlignment" Value="Left" />
-                    </Style>
-                </Grid.Resources>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="10" />
-                    <ColumnDefinition Width="{StaticResource TimestampColumnGridLength}" />
-                    <ColumnDefinition Width="{StaticResource LogLevelColumnGridLength}" />
-                    <ColumnDefinition
-                        Width="*"
-                        MinWidth="{StaticResource MessageColumnMinWidth}" />
-                    <ColumnDefinition Width="10" />
-                </Grid.ColumnDefinitions>
-                <Button
-                    Grid.Column="0"
-                    Grid.ColumnSpan="2"
-                    BorderThickness="0,0,1,1"
-                    Content="Timestamp"
-                    CornerRadius="4,0,0,0" />
-                <Button
-                    Grid.Column="2"
-                    BorderThickness="0,0,1,1"
-                    Content="Level"
-                    CornerRadius="0,0,0,0" />
-                <Button
-                    Grid.Column="3"
-                    Grid.ColumnSpan="2"
-                    BorderThickness="0,0,1,1"
-                    Content="Message"
-                    CornerRadius="0,4,0,0" />
-            </Grid>
-            <ListView
-                x:Name="LogEventsListView"
-                Grid.Row="1"
-                ItemTemplateSelector="{StaticResource LogItemDataTemplateSelector}"
-                ItemsSource="{x:Bind LogEvents, Mode=OneWay}"
-                Visibility="{x:Bind LogViewerVisibilityToggleSwitch.IsOn, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}">
-                <ListView.ItemContainerTransitions>
-                    <TransitionCollection />
-                </ListView.ItemContainerTransitions>
-            </ListView>
-        </Grid>
+        <table:TableView x:Name="LogEventsTableView"
+                         Grid.Column="1"
+                         HeaderRowHeight="32"
+                         ShowOptionsButton="False"
+                         AutoGenerateColumns="False"
+                         ItemsSource="{x:Bind LogEvents}"
+                         Visibility="{x:Bind LogViewerVisibilityToggleSwitch.IsOn, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}">
+            <ListView.ItemContainerTransitions>
+                <TransitionCollection />
+            </ListView.ItemContainerTransitions>
+            <table:TableView.Columns>
+                <table:TableViewTemplateColumn Header="Timestamp"
+                                               Width="210">
+                    <table:TableViewTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Timestamp}"
+                                       Foreground="{Binding Level, Converter={StaticResource LogEventLevelToBrushConverter} }" />
+                        </DataTemplate>
+                    </table:TableViewTemplateColumn.CellTemplate>
+                </table:TableViewTemplateColumn>
+                <table:TableViewTemplateColumn Header="Level"
+                                               Width="90">
+                    <table:TableViewTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Level}"
+                                       Foreground="{Binding Level, Converter={StaticResource LogEventLevelToBrushConverter} }" />
+                        </DataTemplate>
+                    </table:TableViewTemplateColumn.CellTemplate>
+                </table:TableViewTemplateColumn>
+                <table:TableViewTemplateColumn Header="Message"
+                                               Width="600">
+                    <table:TableViewTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Message}"
+                                       Foreground="{Binding Level, Converter={StaticResource LogEventLevelToBrushConverter} }" />
+                        </DataTemplate>
+                    </table:TableViewTemplateColumn.CellTemplate>
+                </table:TableViewTemplateColumn>
+            </table:TableView.Columns>
+        </table:TableView>
     </Grid>
 
 </Page>

--- a/sample/WinUI3SampleApp/MainPage.xaml.cs
+++ b/sample/WinUI3SampleApp/MainPage.xaml.cs
@@ -70,7 +70,7 @@ public sealed partial class MainPage : Page
                 if (AutoScrollToggleSwitch.IsOn is true &&
                     LogEvents.LastOrDefault() is { } logEvent)
                 {
-                    LogEventsListView.ScrollIntoView(logEvent);
+                    LogEventsTableView.ScrollIntoView(logEvent);
                 }
             }
         }

--- a/sample/WinUI3SampleApp/WinUI3SampleApp.csproj
+++ b/sample/WinUI3SampleApp/WinUI3SampleApp.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240404000" />
+    <PackageReference Include="WinUI.TableView" Version="1.1.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 


### PR DESCRIPTION
Replace ListView with WinUI.TableView to simplify the log viewer. It uses templated columns with a textbox in it to show log data. Unlike template selector for different log event levels, now there is a converter to set foreground color.